### PR TITLE
[gunicorn] Listen port in env. variable

### DIFF
--- a/app/gunicorn_config.py
+++ b/app/gunicorn_config.py
@@ -1,3 +1,6 @@
+# stl
+import os
+
 # Sample Gunicorn configuration file.
 
 #
@@ -18,7 +21,9 @@
 #       range.
 #
 
-bind = '0.0.0.0:5000'
+listen_port = os.getenv("LISTEN_PORT", "5000")
+
+bind = '0.0.0.0:{}'.format(listen_port)
 backlog = 2048
 
 #


### PR DESCRIPTION
This makes it easier to use port 80 in `go-morpheo`'s dev. environment.